### PR TITLE
fix module scripts in view rendering

### DIFF
--- a/src/utils/renderView.js
+++ b/src/utils/renderView.js
@@ -35,6 +35,7 @@ export async function renderView(viewPath, model = {}) {
     scripts.map((old) => {
       const s = document.createElement("script");
       for (const { name, value } of old.attributes) s.setAttribute(name, value);
+      const isModule = (old.type || "").toLowerCase() === "module";
       if (old.src) {
         return new Promise((ok, err) => {
           s.onload = ok;
@@ -42,11 +43,18 @@ export async function renderView(viewPath, model = {}) {
           s.src = old.src;
           old.replaceWith(s);
         });
-      } else {
-        s.text = old.textContent || "";
-        old.replaceWith(s);
-        return Promise.resolve();
       }
+      if (isModule) {
+        return new Promise((ok, err) => {
+          s.onload = ok;
+          s.onerror = err;
+          s.text = old.textContent || "";
+          old.replaceWith(s);
+        });
+      }
+      s.text = old.textContent || "";
+      old.replaceWith(s);
+      return Promise.resolve();
     })
   );
 

--- a/src/utils/viewLoader.js
+++ b/src/utils/viewLoader.js
@@ -24,6 +24,7 @@ export async function loadSharedView(elementId, viewName) {
     scripts.map((old) => {
       const s = document.createElement("script");
       for (const { name, value } of old.attributes) s.setAttribute(name, value);
+      const isModule = (old.type || "").toLowerCase() === "module";
       if (old.src) {
         return new Promise((ok, err) => {
           s.onload = ok;
@@ -31,11 +32,18 @@ export async function loadSharedView(elementId, viewName) {
           s.src = old.src;
           old.replaceWith(s);
         });
-      } else {
-        s.text = old.textContent || "";
-        old.replaceWith(s);
-        return Promise.resolve();
       }
+      if (isModule) {
+        return new Promise((ok, err) => {
+          s.onload = ok;
+          s.onerror = err;
+          s.text = old.textContent || "";
+          old.replaceWith(s);
+        });
+      }
+      s.text = old.textContent || "";
+      old.replaceWith(s);
+      return Promise.resolve();
     })
   );
 }

--- a/src/views/Search/Results.html
+++ b/src/views/Search/Results.html
@@ -1,12 +1,13 @@
 <meta name="layout" content="_Layout.html" />
 
 <section class="px-4 py-4">
-  <h1 class="text-2xl font-semibold">Kết quả cho: "{{q}}"</h1>
+  <h1 class="text-2xl font-semibold">Kết quả cho: "<span id="qValue"></span>"</h1>
   <div id="resultZone" class="mt-3"></div>
 </section>
 
 <script type="module">
   window.initView = (m) => {
+    document.getElementById("qValue").textContent = m.q || "";
     const z = document.getElementById("resultZone");
     if (!m.q) {
       z.innerHTML = `<p class="text-slate-600">Nhập từ khoá để tìm kiếm.</p>`;


### PR DESCRIPTION
## Summary
- ensure inline module scripts run by awaiting their load events in view and partial rendering
- update Results view to display query text and use module-friendly init

## Testing
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68baeaa33df4833081c2464c9eaef8ff