### PR TITLE
refactor view loading

### DIFF
--- a/src/utils/renderView.js
+++ b/src/utils/renderView.js
@@ -1,68 +1,40 @@
-// Load TẤT CẢ file HTML trong /src/views dưới dạng chuỗi (raw), không fetch, không bị Vite tiêm @vite/client
-const TPL = import.meta.glob("/src/views/**/*.html", {
-  query: "?raw",
-  import: "default",
-  eager: true,
-});
+import { getTemplate, executeScripts } from './viewLoader.js';
 
 export async function renderView(viewPath, model = {}) {
-  // 1) View HTML
-  const viewFull = `/src/views/${viewPath}`;
-  const viewHtml = TPL[viewFull];
-  if (!viewHtml) throw new Error(`View not found: ${viewFull}`);
+  const viewHtmlRaw = getTemplate(viewPath);
+  if (!viewHtmlRaw) throw new Error(`View not found: /src/views/${viewPath}`);
 
-  // 2) Layout từ <meta name="layout"> (mặc định _Layout.html)
   const layoutName =
-    viewHtml.match(
-      /<meta\s+name=["']layout["']\s+content=["']([^"']+)["']/i
-    )?.[1] || "_Layout.html";
-  const layoutFull = `/src/views/${layoutName}`;
-  const layoutHtml = TPL[layoutFull];
-  if (!layoutHtml) throw new Error(`Layout not found: ${layoutFull}`);
+    viewHtmlRaw.match(/<meta\s+name=['"]layout['"]\s+content=['"]([^'"]+)['"]/i)?.[1] ||
+    '_Layout.html';
+  const layoutHtmlRaw = getTemplate(layoutName);
+  if (!layoutHtmlRaw) throw new Error(`Layout not found: /src/views/${layoutName}`);
 
-  // 3) Merge vào {{{body}}} (+ optional {{title}})
-  const viewBody = viewHtml.replace(/<meta[^>]*>/i, "").trim();
-  let merged = layoutHtml.replace(/{{{body}}}/g, viewBody);
-  merged = merged.replace(/{{title}}/g, model.title ?? "");
+  const viewHtml = viewHtmlRaw.replace(/<meta[^>]*>/i, '').trim();
 
-  // 4) Mount
-  document.body.innerHTML = merged;
+  // chuẩn bị view và chạy script trong view trước
+  document.body.innerHTML = '';
+  const viewContainer = document.createElement('div');
+  viewContainer.innerHTML = viewHtml;
+  document.body.appendChild(viewContainer);
+  await executeScripts(viewContainer, model);
 
-  // 5) Re-exec <script> (layout + view) để initView được định nghĩa
-  delete window.initView;
-  const scripts = Array.from(document.body.querySelectorAll("script"));
-  await Promise.allSettled(
-    scripts.map((old) => {
-      const s = document.createElement("script");
-      for (const { name, value } of old.attributes) s.setAttribute(name, value);
-      const isModule = (old.type || "").toLowerCase() === "module";
-      if (old.src) {
-        return new Promise((ok, err) => {
-          s.onload = ok;
-          s.onerror = err;
-          s.src = old.src;
-          old.replaceWith(s);
-        });
-      }
-      if (isModule) {
-        return new Promise((ok, err) => {
-          s.onload = ok;
-          s.onerror = err;
-          s.text = old.textContent || "";
-          old.replaceWith(s);
-        });
-      }
-      s.text = old.textContent || "";
-      old.replaceWith(s);
-      return Promise.resolve();
-    })
-  );
-
-  // 6) Gọi initView(model) nếu có
-  window.__viewData = model;
-  if (typeof window.initView === "function") {
-    const fn = window.initView;
-    delete window.initView;
-    await fn(model);
+  // chuẩn bị layout, chèn view vào và chạy script trong layout
+  let layoutHtml = layoutHtmlRaw.replace(/{{title}}/g, model.title ?? '');
+  layoutHtml = layoutHtml.replace(/{{{body}}}/g, '<div id="__view_placeholder__"></div>');
+  const layoutContainer = document.createElement('div');
+  layoutContainer.innerHTML = layoutHtml;
+  const placeholder = layoutContainer.querySelector('#__view_placeholder__');
+  if (placeholder) {
+    while (viewContainer.firstChild) {
+      placeholder.appendChild(viewContainer.firstChild);
+    }
   }
+
+  document.body.innerHTML = '';
+  while (layoutContainer.firstChild) {
+    document.body.appendChild(layoutContainer.firstChild);
+  }
+
+  await executeScripts(document.body, model);
 }


### PR DESCRIPTION
## Summary
- rewrite view loader to fetch partials and run their scripts with a model
- restructure view rendering to execute view scripts before layout scripts and merge with layout using models

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baedb21a1883309be776edbfc0f124